### PR TITLE
Fixing a 'contains unrecognized parameter: [all]' error

### DIFF
--- a/elasticsearch_node_status/elasticsearch_node_status.rb
+++ b/elasticsearch_node_status/elasticsearch_node_status.rb
@@ -37,7 +37,7 @@ class ElasticsearchClusterNodeStatus < Scout::Plugin
       return error("Please provide both username and password", "Both the elasticsearch username and password to monitor the protected cluster are required.\n\nUsername: #{option(:username)}\n\nPassword: #{option(:password)}")
     end
 
-    base_url = "#{option(:elasticsearch_host)}:#{option(:elasticsearch_port)}#{uri_path}/#{node_name}/stats?all=true"
+    base_url = "#{option(:elasticsearch_host)}:#{option(:elasticsearch_port)}#{uri_path}/#{node_name}/stats"
 
     response = get_response(base_url)
     resp = JSON.parse(response.body)


### PR DESCRIPTION
I have changed the term '/stats?all=true' to '/stats' in the base url template in line 40 so the http request doesn't return an 'contains unrecognized parameter: [all]' error.  This has been tested on a machine which runs the plugin to monitor the status of some AWS elastic search nodes. FYI, The actual plugin doesn't display this root cause error, it has shown "No node in the cluster could be found with the specified name. Node Name: <my_node_name>' instead which is part of the plugin's own error handle.

So if I run
'''curl -XGET https://<host_url>/_nodes/FrolxhN/stats?all=true'''

#=> {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"request [/_nodes/<my_node_name>/stats] contains unrecognized parameter: [all]"}],"type":"illegal_argument_exception","reason":"request [/_nodes/<my_node_name>/stats] contains unrecognized parameter: [all]"},"status":400}[