### PR TITLE
Elasticsearch Index: Support aliases

### DIFF
--- a/elasticsearch_index_status/elasticsearch_index_status.rb
+++ b/elasticsearch_index_status/elasticsearch_index_status.rb
@@ -22,7 +22,7 @@ class ElasticsearchIndexStatus < Scout::Plugin
       notes: Password used to log into elasticsearch host if authentication is enabled.
     index_name:
       name: Index name
-      notes: Name of the index you wish to monitor
+      notes: Name of the index or index alias you wish to monitor
   EOS
 
   needs 'net/http', 'net/https', 'json', 'open-uri'


### PR DESCRIPTION
This is to address issue #177 

Will work with one:one aliases of indices in `index_name` and with proper index names for `index_name`. For many:one aliases it will use the first index it finds.