### PR TITLE
Close DB connection tidily

### DIFF
--- a/mysql2_replication_monitor/mysql_replication_monitor.rb
+++ b/mysql2_replication_monitor/mysql_replication_monitor.rb
@@ -91,6 +91,7 @@ class MysqlReplicationMonitor < Scout::Plugin
       end
     end
     report(res)
+    connection.close
   end
 
   def in_ignore_window?


### PR DESCRIPTION
Without this close of the connection the MySQL error.log fills up with this every minute:

```
2018-03-19T17:33:03.675831Z 261 [Note] Aborted connection 261 to db: 'unconnected' user: 'root' host: 'localhost' (Got an error reading communication packets)
```

These logs only started happening for me after upgrade from MySQL 5.6 to 5.7