### PR TITLE
Modify Varnish plugin regex

### DIFF
--- a/varnish/varnish.rb
+++ b/varnish/varnish.rb
@@ -35,7 +35,7 @@ class Varnish < Scout::Plugin
     end
     res.each_line do |line|
       #client_conn 211980 0.30 Client connections accepted
-      next unless /\A([\.\w]+)\s+(\d+)\s+(\d+\.\d+)\s(.+)\Z/.match(line)
+      next unless /\A([\.\w]+)\s+(\d+)\s+(\d*\.\d*)\s(.+)\Z/.match(line)
       stats[$1] = $2.to_i
     end
 


### PR DESCRIPTION
This way, the plugin will accept metrics such as: 
```
MAIN.cache_hit             22980         0.04   Cache hits
MAIN.n_object              11329            .   object structs made
```
where the *"count"* is not a number but a dot ("`.`").

The issue was reported by a customer, who has been facing errors due to this regular expression.

**Please let me know if there was a reason for keeping the `\d+` statement**
