### PR TITLE
Allow setting rediss protocol for Sidekiq plugin

### DIFF
--- a/sidekiq_monitor/sidekiq_monitor.rb
+++ b/sidekiq_monitor/sidekiq_monitor.rb
@@ -18,6 +18,9 @@ class SidekiqMonitor < Scout::Plugin
     name: Port
     notes: Redis port to pass to the client library.
     default: 6379
+  rediss:
+    name: Rediss Protocol
+    notes: Whether to use the rediss protocol
   db:
     name: Database
     notes: Redis database ID to pass to the client library.
@@ -36,7 +39,7 @@ class SidekiqMonitor < Scout::Plugin
   EOS
 
   def build_report
-    protocol = 'redis://'
+    protocol = options[:rediss] ? 'rediss://' : 'redis://'
     auth = [(option(:username) || ""), option(:password)].compact.join(':')
     path = "#{option(:host)}:#{option(:port)}/#{option(:db)}"
 

--- a/sidekiq_monitor/sidekiq_monitor.rb
+++ b/sidekiq_monitor/sidekiq_monitor.rb
@@ -20,7 +20,8 @@ class SidekiqMonitor < Scout::Plugin
     default: 6379
   rediss:
     name: Rediss Protocol
-    notes: Whether to use the rediss protocol
+    notes: Whether to use the rediss protocol (specify 'true' to enable)
+    attributes: advanced
   db:
     name: Database
     notes: Redis database ID to pass to the client library.
@@ -39,7 +40,7 @@ class SidekiqMonitor < Scout::Plugin
   EOS
 
   def build_report
-    protocol = options[:rediss] ? 'rediss://' : 'redis://'
+    protocol = options[:rediss].to_s.strip == 'true' ? 'rediss://' : 'redis://'
     auth = [(option(:username) || ""), option(:password)].compact.join(':')
     path = "#{option(:host)}:#{option(:port)}/#{option(:db)}"
 


### PR DESCRIPTION
This allows people using the Rediss protocol for encryption to use the plugin. This can be used, for example, on Amazon Elasticache Redis.

Not sure if there's a way to make this into a checkbox rather than an input field. I think currently if you ever set this and then try to unset it (to an empty string) it might just get considered as true. Alternatively, this could just be a protocol option, but that might be weird to allow.