### PR TITLE
Update regexp to match different date formats for mysql slow queries

### DIFF
--- a/mysql_slow_queries/mysql_slow_queries.rb
+++ b/mysql_slow_queries/mysql_slow_queries.rb
@@ -52,7 +52,7 @@ class ScoutMysqlSlow < Scout::Plugin
         query_time = $1.to_f
         all_queries << {:query_time => query_time, :sql => sql.reverse}
         sql = []
-      elsif line =~ /^\# Time: (\d+ .*)$/
+      elsif line =~ /^\# Time: (\d+ .*|\d{2,4}\-\d{1,2}\-\d{1,2}.*)$/
         # We now have a complete entry. capture its timestamp:
         # split w/# is for ey compatibility. 
         temp_timestamp = Time.parse($1.split('#')[0]) {|y| y < 100 ? y + 2000 : y}


### PR DESCRIPTION
This way it will match `# Time: 170901 20:42:10` and `# Time: 2018-11-01T05:07:38.976987Z`.

The parser (`Time.parse($1.split('#')[0]) {|y| y < 100 ? y + 2000 : y}`) works for both.