### PR TITLE
Fix tomcat log format example in comment

### DIFF
--- a/tomcat_monitor/tomcat_monitor.rb
+++ b/tomcat_monitor/tomcat_monitor.rb
@@ -175,7 +175,8 @@ class TomcatMonitor < Scout::Plugin
   # LOG PARSING
   #################
 
-  # assumes format:  10.162.73.221 - - [23/Apr/2011:00:00:40 +0000] "GET /client/appraisalWorkshopPrintSignReport.jsp HTTP/1.1" 200 80557
+  # assumes format: 10.162.73.221 - - [23/Apr/2011:00:00:40 +0000] 80557 "GET /client/appraisalWorkshopPrintSignReport.jsp HTTP/1.1" 200
+  # use this pattern in server.xml: '%h %l %u %t %D "%r" %s %b"'
   def parse_logs
     logs = ""
     begin


### PR DESCRIPTION
This commit fixes a comment that describes the acceptable log format for the tomcat-monitor plugin. Now it matches the code.

I also added a comment describing the pattern to use in `server.xml` to get tomcat to output this format.
