### PR TITLE
Sidekiq Monitor: Report default_queue_latency

### DIFF
--- a/sidekiq_monitor/sidekiq_monitor.rb
+++ b/sidekiq_monitor/sidekiq_monitor.rb
@@ -57,7 +57,7 @@ class SidekiqMonitor < Scout::Plugin
     begin
       stats = Sidekiq::Stats.new
 
-      [:enqueued, :failed, :processed, :scheduled_size, :retry_size].each do |name|
+      [:enqueued, :failed, :processed, :scheduled_size, :retry_size, :default_queue_latency].each do |name|
         report(name => stats.send(name))
         counter("#{name}_per_minute".to_sym, stats.send(name), :per => :minute)
       end


### PR DESCRIPTION
This is useful to see if Sidekiq is backed up.

Not sure if the per minute stats make sense for this, but I guess it's fine for now. If it's just adding up the sampled latency metrics for each minute though, that doesn't really make a lot of sense.

Could also add the following instead to avoid sending a misleading per minute figure:

```ruby
      report(default_queue_latency:  stats.send(:default_queue_latency))
```